### PR TITLE
Colors 2

### DIFF
--- a/@kth/style/scss/components/button.scss
+++ b/@kth/style/scss/components/button.scss
@@ -12,10 +12,6 @@
     border-radius: 100%;
   }
 
-  .kth-button:hover {
-    background: var(--color-hover-overlay, transparent);
-  }
-
   .kth-button.close::before {
     content: "";
     display: inline-block;

--- a/@kth/style/scss/components/button.scss
+++ b/@kth/style/scss/components/button.scss
@@ -7,8 +7,13 @@
     margin-inline-start: auto;
     background: transparent;
     border: none;
-    padding-inline: 0;
+    padding-inline: spacing.$space-8;
     padding-block: spacing.$space-8;
+    border-radius: 100%;
+  }
+
+  .kth-button:hover {
+    background: var(--color-hover-overlay, transparent);
   }
 
   .kth-button.close::before {

--- a/@kth/style/scss/tokens/colors.scss
+++ b/@kth/style/scss/tokens/colors.scss
@@ -18,10 +18,10 @@ $color-blue-digital: #221dd9;
 
 // Other colors, defined by us to meet various needs
 $color-red-light: #fad6d6;
-$color-red: #d8351e;
+$color-red: #c7321d;
 $color-red-dark: #bf2c17;
 $color-green-light: #d8ffe7;
-$color-green: #3f824e;
+$color-green: #3d784a;
 $color-green-dark: #366f43;
 
 $color-black-20: rgba(33, 33, 33, 0.07);

--- a/@kth/style/scss/tokens/colors.scss
+++ b/@kth/style/scss/tokens/colors.scss
@@ -1,6 +1,8 @@
 // Gray-scale
 $color-white: #fcfcfc;
 $color-black: #212121;
+$color-gray-lightest: #f2f2f2;
+$color-gray-lighter: #ededed;
 $color-gray-light: #e6e6e6;
 $color-gray-medium: #a5a5a5;
 $color-gray-dark: #323232;
@@ -28,6 +30,7 @@ $color-white-20: rgba(252, 252, 252, 0.2);
 @mixin theme-default {
   --color-text: #{$color-black};
   --color-background: #{$color-white};
+  --color-background-alt: #{$color-gray-lighter};
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
@@ -40,6 +43,7 @@ $color-white-20: rgba(252, 252, 252, 0.2);
 @mixin theme-student-web {
   --color-text: #{$color-black};
   --color-background: #{$color-blue-light};
+  --color-background-alt: #{$color-gray-lighter};
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
@@ -52,6 +56,7 @@ $color-white-20: rgba(252, 252, 252, 0.2);
 @mixin theme-intranet {
   --color-text: #{$color-black};
   --color-background: #{$color-sand};
+  --color-background-alt: #{$color-gray-lightest};
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
@@ -64,6 +69,7 @@ $color-white-20: rgba(252, 252, 252, 0.2);
 @mixin theme-inverse {
   --color-text: #{$color-white};
   --color-background: #{$color-blue-kth};
+  --color-background-alt: #{$color-blue-marine};
   --color-primary: #{$color-white};
   --color-on-primary: #{$color-blue-kth};
   --color-secondary: #{$color-white};

--- a/@kth/style/scss/tokens/colors.scss
+++ b/@kth/style/scss/tokens/colors.scss
@@ -24,9 +24,6 @@ $color-green-light: #d8ffe7;
 $color-green: #3d784a;
 $color-green-dark: #366f43;
 
-$color-black-20: rgba(33, 33, 33, 0.07);
-$color-white-20: rgba(252, 252, 252, 0.2);
-
 @mixin theme-default {
   --color-text: #{$color-black};
   --color-background: #{$color-white};
@@ -37,7 +34,6 @@ $color-white-20: rgba(252, 252, 252, 0.2);
   --color-tertiary: #{$color-blue-lake};
   --color-error: #{$color-red};
   --color-success: #{$color-green};
-  --color-hover-overlay: #{$color-black-20};
 }
 
 @mixin theme-student-web {
@@ -50,7 +46,6 @@ $color-white-20: rgba(252, 252, 252, 0.2);
   --color-tertiary: #{$color-blue-lake};
   --color-error: #{$color-red-dark};
   --color-success: #{$color-green-dark};
-  --color-hover-overlay: #{$color-black-20};
 }
 
 @mixin theme-intranet {
@@ -63,7 +58,6 @@ $color-white-20: rgba(252, 252, 252, 0.2);
   --color-tertiary: #{$color-blue-kth};
   --color-error: #{$color-red-dark};
   --color-success: #{$color-green-dark};
-  --color-hover-overlay: #{$color-black-20};
 }
 
 @mixin theme-inverse {
@@ -76,5 +70,4 @@ $color-white-20: rgba(252, 252, 252, 0.2);
   --color-tertiary: #{$color-white};
   --color-error: #{$color-red-light};
   --color-success: #{$color-green-light};
-  --color-hover-overlay: #{$color-black-20};
 }

--- a/@kth/style/scss/tokens/colors.scss
+++ b/@kth/style/scss/tokens/colors.scss
@@ -22,6 +22,9 @@ $color-green-light: #d8ffe7;
 $color-green: #3f824e;
 $color-green-dark: #366f43;
 
+$color-black-20: rgba(33, 33, 33, 0.07);
+$color-white-20: rgba(252, 252, 252, 0.2);
+
 @mixin theme-default {
   --color-text: #{$color-black};
   --color-background: #{$color-white};
@@ -31,6 +34,7 @@ $color-green-dark: #366f43;
   --color-tertiary: #{$color-blue-lake};
   --color-error: #{$color-red};
   --color-success: #{$color-green};
+  --color-hover-overlay: #{$color-black-20};
 }
 
 @mixin theme-student-web {
@@ -42,6 +46,7 @@ $color-green-dark: #366f43;
   --color-tertiary: #{$color-blue-lake};
   --color-error: #{$color-red-dark};
   --color-success: #{$color-green-dark};
+  --color-hover-overlay: #{$color-black-20};
 }
 
 @mixin theme-intranet {
@@ -53,6 +58,7 @@ $color-green-dark: #366f43;
   --color-tertiary: #{$color-blue-kth};
   --color-error: #{$color-red-dark};
   --color-success: #{$color-green-dark};
+  --color-hover-overlay: #{$color-black-20};
 }
 
 @mixin theme-inverse {
@@ -64,4 +70,5 @@ $color-green-dark: #366f43;
   --color-tertiary: #{$color-white};
   --color-error: #{$color-red-light};
   --color-success: #{$color-green-light};
+  --color-hover-overlay: #{$color-black-20};
 }

--- a/@kth/style/scss/tokens/colors.scss
+++ b/@kth/style/scss/tokens/colors.scss
@@ -14,11 +14,13 @@ $color-blue-lake: #036eb8; // This is defined by us for links
 $color-blue-marine: #08004f;
 $color-blue-digital: #221dd9;
 
-// This color is specially made for links
-// 4.51:1 with `$color-blue-light` (requires 4.50)
-// 5.21:1 with `$color-white`      (requires 4.50)
-// 3.01:1 with `$color-black`      (requires 3.00)
-$color-blue-special: #036eb8;
+// Other colors, defined by us to meet various needs
+$color-red-light: #fad6d6;
+$color-red: #d8351e;
+$color-red-dark: #bf2c17;
+$color-green-light: #d8ffe7;
+$color-green: #3f824e;
+$color-green-dark: #366f43;
 
 @mixin theme-default {
   --color-text: #{$color-black};
@@ -27,7 +29,8 @@ $color-blue-special: #036eb8;
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
   --color-tertiary: #{$color-blue-lake};
-  // ... --hover-overlay: ...
+  --color-error: #{$color-red};
+  --color-success: #{$color-green};
 }
 
 @mixin theme-student-web {
@@ -37,7 +40,8 @@ $color-blue-special: #036eb8;
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
   --color-tertiary: #{$color-blue-lake};
-  // ... --hover-overlay: ...
+  --color-error: #{$color-red-dark};
+  --color-success: #{$color-green-dark};
 }
 
 @mixin theme-intranet {
@@ -46,8 +50,9 @@ $color-blue-special: #036eb8;
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
-  --color-tertiary: #{$color-blue-lake};
-  // ... --hover-overlay: ...
+  --color-tertiary: #{$color-blue-kth};
+  --color-error: #{$color-red-dark};
+  --color-success: #{$color-green-dark};
 }
 
 @mixin theme-inverse {
@@ -57,5 +62,6 @@ $color-blue-special: #036eb8;
   --color-on-primary: #{$color-blue-kth};
   --color-secondary: #{$color-white};
   --color-tertiary: #{$color-white};
-  // ... --hover-overlay: ...
+  --color-error: #{$color-red-light};
+  --color-success: #{$color-green-light};
 }

--- a/@kth/style/scss/tokens/colors.scss
+++ b/@kth/style/scss/tokens/colors.scss
@@ -10,6 +10,7 @@ $color-sand: #e6e1dd;
 $color-blue-kth: #004791;
 $color-blue-light: #e0edfc;
 $color-blue-sky: #6298d2;
+$color-blue-lake: #036eb8; // This is defined by us for links
 $color-blue-marine: #08004f;
 $color-blue-digital: #221dd9;
 
@@ -25,7 +26,7 @@ $color-blue-special: #036eb8;
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
-  --color-tertiary: #{$color-blue-special};
+  --color-tertiary: #{$color-blue-lake};
   // ... --hover-overlay: ...
 }
 
@@ -35,7 +36,7 @@ $color-blue-special: #036eb8;
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
-  --color-tertiary: #{$color-blue-special};
+  --color-tertiary: #{$color-blue-lake};
   // ... --hover-overlay: ...
 }
 
@@ -45,7 +46,7 @@ $color-blue-special: #036eb8;
   --color-primary: #{$color-blue-kth};
   --color-on-primary: #{$color-white};
   --color-secondary: #{$color-black};
-  --color-tertiary: #{$color-blue-special};
+  --color-tertiary: #{$color-blue-lake};
   // ... --hover-overlay: ...
 }
 

--- a/@kth/style/scss/utils/prose.scss
+++ b/@kth/style/scss/utils/prose.scss
@@ -105,7 +105,6 @@
     // TODO: border
 
     td {
-      vertical-align: baseline;
       padding-block: var(--space-inner-block);
       padding-inline: var(--space-inner-inline);
 

--- a/apps/style-web/src/components/a11y-colors.ts
+++ b/apps/style-web/src/components/a11y-colors.ts
@@ -1,0 +1,60 @@
+interface LColor {
+  lr: number;
+  lg: number;
+  lb: number;
+}
+
+export class Color {
+  r: number;
+  g: number;
+  b: number;
+
+  constructor(r: number, g: number, b: number) {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+  }
+
+  lrgb(): LColor {
+    function t(n: number) {
+      if (n < 0.03928) {
+        return n / 12.92;
+      } else {
+        return Math.pow((n + 0.055) / 1.055, 2.4);
+      }
+    }
+
+    return {
+      lr: t(this.r / 255),
+      lg: t(this.g / 255),
+      lb: t(this.b / 255),
+    };
+  }
+
+  luminance() {
+    const color = this.lrgb();
+
+    return 0.2126 * color.lr + 0.7152 * color.lg + 0.0722 * color.lb;
+  }
+
+  static fromHex(hex: string) {
+    return new Color(
+      parseInt(hex.slice(1, 3), 16),
+      parseInt(hex.slice(3, 5), 16),
+      parseInt(hex.slice(5, 7), 16),
+    );
+  }
+}
+
+export function wcagContrast(c1: Color, c2: Color): number {
+  const l1 = c1.luminance();
+  const l2 = c2.luminance();
+
+  if (l1 > l2) {
+    return (l1 + 0.05) / (l2 + 0.05);
+  } else {
+    return (l2 + 0.05) / (l1 + 0.05);
+  }
+}
+
+function updateTable() {}

--- a/apps/style-web/src/components/color-table.scss
+++ b/apps/style-web/src/components/color-table.scss
@@ -1,0 +1,16 @@
+@use "@kth/style/scss/tokens/spacing" as s;
+styleweb-color-table {
+  .styleweb-swatch {
+    display: flex;
+    gap: 0 s.$space-12;
+
+    &::before {
+      content: " ";
+      display: block;
+      background: var(--color);
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 100%;
+    }
+  }
+}

--- a/apps/style-web/src/components/color-table.ts
+++ b/apps/style-web/src/components/color-table.ts
@@ -1,0 +1,24 @@
+export class ColorTable extends HTMLElement {
+  constructor() {
+    super();
+
+    const cells = this.querySelector("table")?.querySelectorAll("td");
+
+    if (!cells) {
+      return;
+    }
+
+    for (const cell of cells) {
+      const text = cell.textContent || "";
+
+      if (/\#\w{6}/.test(text)) {
+        const newElement = document.createElement("div");
+        newElement.classList.add("styleweb-swatch");
+        newElement.style.setProperty("--color", text);
+        newElement.innerHTML = text;
+
+        cell.replaceChildren(newElement);
+      }
+    }
+  }
+}

--- a/apps/style-web/src/layouts/Page.astro
+++ b/apps/style-web/src/layouts/Page.astro
@@ -6,6 +6,7 @@ type Props = MarkdownLayoutProps<{
 }>;
 
 import "./Page.scss";
+import "@components/color-table.scss";
 import Layout from "./Layout.astro";
 import Kpm from "../components/Kpm.astro";
 import Header from "../components/Header.astro";
@@ -24,4 +25,9 @@ const { frontmatter } = Astro.props;
     <Sidebar />
     <main id="kth-main"><slot /></main>
   </div>
+  <script>
+    import { ColorTable } from "@components/color-table.ts";
+
+    window.customElements.define("styleweb-color-table", ColorTable);
+  </script>
 </Layout>

--- a/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
+++ b/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
@@ -8,24 +8,37 @@ import Sidebar from "@components/Sidebar.astro";
 const properties = [
   "--color-text",
   "--color-background",
+  "--color-background-alt",
   "--color-primary",
   "--color-secondary",
   "--color-tertiary",
   "--color-error",
   "--color-success",
   "--color-on-primary",
-];
+] as const;
 
-const tests = [
+type PROPERTIES = (typeof properties)[number];
+
+const tests: { c1: PROPERTIES; c2: PROPERTIES; r: number }[] = [
   { c1: "--color-background", c2: "--color-text", r: 7 },
+  { c1: "--color-background-alt", c2: "--color-text", r: 7 },
+
   { c1: "--color-background", c2: "--color-primary", r: 4.5 },
   { c1: "--color-background", c2: "--color-error", r: 4.5 },
   { c1: "--color-background", c2: "--color-success", r: 4.5 },
+  { c1: "--color-background-alt", c2: "--color-primary", r: 4.5 },
+  { c1: "--color-background-alt", c2: "--color-error", r: 4.5 },
+  { c1: "--color-background-alt", c2: "--color-success", r: 4.5 },
+
   { c1: "--color-primary", c2: "--color-on-primary", r: 4.5 },
   { c1: "--color-error", c2: "--color-on-primary", r: 4.5 },
   { c1: "--color-success", c2: "--color-on-primary", r: 4.5 },
+
   { c1: "--color-background", c2: "--color-secondary", r: 4.5 },
   { c1: "--color-background", c2: "--color-tertiary", r: 4.5 },
+  { c1: "--color-background-alt", c2: "--color-secondary", r: 4.5 },
+  { c1: "--color-background-alt", c2: "--color-tertiary", r: 4.5 },
+
   { c1: "--color-text", c2: "--color-tertiary", r: 3 },
 ];
 ---
@@ -172,7 +185,7 @@ const tests = [
         const c1hex = getColorFromSource(source, row.dataset.color1 || "");
         const c2hex = getColorFromSource(source, row.dataset.color2 || "");
 
-        const requirement = parseInt(row.dataset.requirement || "0", 10);
+        const requirement = parseFloat(row.dataset.requirement || "0");
 
         const actual = wcagContrast(
           Color.fromHex(c1hex || ""),

--- a/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
+++ b/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
@@ -70,7 +70,9 @@ const tests = [
             }
           </tbody>
         </table>
-        <button class="kth-button primary">See the results</button>
+        <button class="kth-button primary" type="submit">
+          See the results
+        </button>
       </form>
 
       <h2>See the results</h2>
@@ -117,7 +119,10 @@ const tests = [
      * Updates color table with values from CSS custom properties
      * taken from the `source`
      */
-    function updateColorTable(table: HTMLElement, source: HTMLElement) {
+    function updateColorTable() {
+      const table = document.getElementById("a11y-table")!;
+      const source = document.getElementById("a11y-theme")!;
+
       const rows =
         table.querySelectorAll<HTMLTableRowElement>("tr[data-property]");
 
@@ -130,12 +135,11 @@ const tests = [
       }
     }
 
-    updateColorTable(
-      document.getElementById("a11y-table")!,
-      document.getElementById("a11y-theme")!,
-    );
+    /** Update the test table from the colors taken from the `source` */
+    function updateTestTable() {
+      const testTable = document.getElementById("a11y-test-table")!;
+      const source = document.getElementById("a11y-theme")!;
 
-    function updateTestTable(testTable: HTMLElement, source: HTMLElement) {
       const rows = testTable.querySelectorAll<HTMLTableRowElement>("tbody tr");
 
       for (const row of rows) {
@@ -155,9 +159,15 @@ const tests = [
       }
     }
 
-    updateTestTable(
-      document.getElementById("a11y-test-table")!,
-      document.getElementById("a11y-theme")!,
-    );
+    updateColorTable();
+    updateTestTable();
+
+    document
+      .querySelector<HTMLButtonElement>("button[type='submit']")!
+      .addEventListener("click", (event) => {
+        event.preventDefault();
+        console.log("BAH");
+        updateTestTable();
+      });
   </script>
 </Layout>

--- a/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
+++ b/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
@@ -43,15 +43,15 @@ const tests = [
       <form>
         <h2>Choose a preset</h2>
         <ul>
-          <li><button>Default theme</button></li>
-          <li><button>Intranet theme</button></li>
-          <li><button>Student web theme</button></li>
-          <li><button>Inverse theme</button></li>
+          <li><button data-theme="default">Default theme</button></li>
+          <li><button data-theme="intranet">Intranet theme</button></li>
+          <li><button data-theme="student-web">Student web theme</button></li>
+          <li><button data-theme="inverse">Inverse theme</button></li>
         </ul>
 
         <div id="a11y-theme" class="default"></div>
 
-        <h2>Customize the colors</h2>
+        <h2>See the colors</h2>
 
         <table id="a11y-table">
           <tbody>
@@ -70,9 +70,6 @@ const tests = [
             }
           </tbody>
         </table>
-        <button class="kth-button primary" type="submit">
-          See the results
-        </button>
       </form>
 
       <h2>See the results</h2>
@@ -106,10 +103,45 @@ const tests = [
       </table>
 
       <h2>Explanations</h2>
+
+      <p>
+        All colors in a given theme must met the WCAG contrast requirements for
+        the purpose that are designed for.
+      </p>
+
+      <ul>
+        <li>
+          `--color-background` and `--color-text` should have as highest
+          contrast as possible since they are colors for background and normal
+          text. At least 7:1 is desired
+        </li>
+        <li>
+          `--color-background` should have contrast with `--color-primary`,
+          `--color-error` and `--color-success` (all of the three) of at least
+          4.5:1 since the latter three appear always on the background.
+        </li>
+        <li>
+          `--color-on-primary` should have contrast with `--color-primary`,
+          `--color-error` and `--color-success` (all of the three) of at least
+          4.5:1
+        </li>
+        <li>
+          `--color-secondary` should have 4.5:1 contrast with
+          `--color-background`
+        </li>
+        <li>
+          `--color-tertiary` should have 4.5:1 contrast with
+          `--color-bacakground`. It is recommended to have a 3:1 contrast with
+          `--color-text`.
+        </li>
+      </ul>
     </main>
   </div>
   <script>
     import { wcagContrast, Color } from "@components/a11y-colors";
+    const testTable = document.getElementById("a11y-test-table")!;
+    const table = document.getElementById("a11y-table")!;
+    const source = document.getElementById("a11y-theme")!;
 
     function getColorFromSource(source: HTMLElement, property: string) {
       return window.getComputedStyle(source).getPropertyValue(property) || "";
@@ -120,9 +152,6 @@ const tests = [
      * taken from the `source`
      */
     function updateColorTable() {
-      const table = document.getElementById("a11y-table")!;
-      const source = document.getElementById("a11y-theme")!;
-
       const rows =
         table.querySelectorAll<HTMLTableRowElement>("tr[data-property]");
 
@@ -137,9 +166,6 @@ const tests = [
 
     /** Update the test table from the colors taken from the `source` */
     function updateTestTable() {
-      const testTable = document.getElementById("a11y-test-table")!;
-      const source = document.getElementById("a11y-theme")!;
-
       const rows = testTable.querySelectorAll<HTMLTableRowElement>("tbody tr");
 
       for (const row of rows) {
@@ -161,6 +187,18 @@ const tests = [
 
     updateColorTable();
     updateTestTable();
+
+    document
+      .querySelectorAll<HTMLButtonElement>("button[data-theme]")
+      .forEach((button) => {
+        button.addEventListener("click", (event) => {
+          event.preventDefault();
+
+          source.className = button.dataset.theme || "default";
+          updateColorTable();
+          updateTestTable();
+        });
+      });
 
     document
       .querySelector<HTMLButtonElement>("button[type='submit']")!

--- a/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
+++ b/apps/style-web/src/pages/style/en/examples/a11y-colors.astro
@@ -1,0 +1,163 @@
+---
+import Layout from "@layouts/Layout.astro";
+import "./a11y-colors.scss";
+import Kpm from "@components/Kpm.astro";
+import Header from "@components/Header.astro";
+import Sidebar from "@components/Sidebar.astro";
+
+const properties = [
+  "--color-text",
+  "--color-background",
+  "--color-primary",
+  "--color-secondary",
+  "--color-tertiary",
+  "--color-error",
+  "--color-success",
+  "--color-on-primary",
+];
+
+const tests = [
+  { c1: "--color-background", c2: "--color-text", r: 7 },
+  { c1: "--color-background", c2: "--color-primary", r: 4.5 },
+  { c1: "--color-background", c2: "--color-error", r: 4.5 },
+  { c1: "--color-background", c2: "--color-success", r: 4.5 },
+  { c1: "--color-primary", c2: "--color-on-primary", r: 4.5 },
+  { c1: "--color-error", c2: "--color-on-primary", r: 4.5 },
+  { c1: "--color-success", c2: "--color-on-primary", r: 4.5 },
+  { c1: "--color-background", c2: "--color-secondary", r: 4.5 },
+  { c1: "--color-background", c2: "--color-tertiary", r: 4.5 },
+  { c1: "--color-text", c2: "--color-tertiary", r: 3 },
+];
+---
+
+<Layout title="Color accessibility test">
+  <div class="kth-a11y-nav"></div>
+  <Kpm />
+  <Header />
+  <div class="kth-content">
+    <Sidebar />
+    <main>
+      <h1>Color accessibility test</h1>
+      <p class="lead">Test WCAG accessibility requirements of our colors</p>
+
+      <form>
+        <h2>Choose a preset</h2>
+        <ul>
+          <li><button>Default theme</button></li>
+          <li><button>Intranet theme</button></li>
+          <li><button>Student web theme</button></li>
+          <li><button>Inverse theme</button></li>
+        </ul>
+
+        <div id="a11y-theme" class="default"></div>
+
+        <h2>Customize the colors</h2>
+
+        <table id="a11y-table">
+          <tbody>
+            {
+              properties.map((property) => (
+                <tr data-property={property}>
+                  <td>
+                    <code>{property}</code>
+                  </td>
+                  <td class="label">N/A</td>
+                  <td>
+                    <input type="color" name={property} />
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+        <button class="kth-button primary">See the results</button>
+      </form>
+
+      <h2>See the results</h2>
+      <table id="a11y-test-table">
+        <thead>
+          <tr>
+            <th>Color 1</th>
+            <th>Color 2</th>
+            <th>Requirement</th>
+            <th>Actual</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            tests.map((test) => (
+              <tr
+                data-color1={test.c1}
+                data-color2={test.c2}
+                data-requirement={test.r}
+              >
+                <td>{test.c1}</td>
+                <td>{test.c2}</td>
+                <td>{test.r}</td>
+                <td class="actual" />
+                <td class="result" />
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
+
+      <h2>Explanations</h2>
+    </main>
+  </div>
+  <script>
+    import { wcagContrast, Color } from "@components/a11y-colors";
+
+    function getColorFromSource(source: HTMLElement, property: string) {
+      return window.getComputedStyle(source).getPropertyValue(property) || "";
+    }
+
+    /**
+     * Updates color table with values from CSS custom properties
+     * taken from the `source`
+     */
+    function updateColorTable(table: HTMLElement, source: HTMLElement) {
+      const rows =
+        table.querySelectorAll<HTMLTableRowElement>("tr[data-property]");
+
+      for (const row of rows) {
+        const propertyName = row.dataset.property || "";
+        const value = getColorFromSource(source, propertyName);
+
+        row.querySelector(".label")!.innerHTML = value;
+        row.querySelector("input")!.value = value;
+      }
+    }
+
+    updateColorTable(
+      document.getElementById("a11y-table")!,
+      document.getElementById("a11y-theme")!,
+    );
+
+    function updateTestTable(testTable: HTMLElement, source: HTMLElement) {
+      const rows = testTable.querySelectorAll<HTMLTableRowElement>("tbody tr");
+
+      for (const row of rows) {
+        const c1hex = getColorFromSource(source, row.dataset.color1 || "");
+        const c2hex = getColorFromSource(source, row.dataset.color2 || "");
+
+        const requirement = parseInt(row.dataset.requirement || "0", 10);
+
+        const actual = wcagContrast(
+          Color.fromHex(c1hex || ""),
+          Color.fromHex(c2hex || ""),
+        );
+
+        row.querySelector("td.actual")!.innerHTML = actual.toFixed(2);
+        row.querySelector("td.result")!.innerHTML =
+          actual >= requirement ? "PASS" : "FAIL";
+      }
+    }
+
+    updateTestTable(
+      document.getElementById("a11y-test-table")!,
+      document.getElementById("a11y-theme")!,
+    );
+  </script>
+</Layout>

--- a/apps/style-web/src/pages/style/en/examples/a11y-colors.scss
+++ b/apps/style-web/src/pages/style/en/examples/a11y-colors.scss
@@ -1,0 +1,31 @@
+@use "@kth/style/scss/tokens/spacing";
+@use "@kth/style/scss/tokens/icons";
+@use "@kth/style/scss/tokens/colors";
+@use "@kth/style/scss/utils/reset";
+@use "@kth/style/scss/utils/prose";
+@use "@kth/style/scss/components/a11y-nav";
+@use "@kth/style/scss/components/menu-item";
+@use "@kth/style/scss/components/header";
+@use "@kth/style/scss/components/search";
+
+@use "@components/content.scss";
+@use "@components/local-navigation.scss";
+
+main {
+  @include prose.prose;
+}
+
+#a11y-theme.default {
+  @include colors.theme-default;
+}
+
+#a11y-theme.student-web {
+  @include colors.theme-student-web;
+}
+
+#a11y-theme.intranet {
+  @include colors.theme-intranet;
+}
+#a11y-theme.inverse {
+  @include colors.theme-inverse;
+}

--- a/apps/style-web/src/pages/style/en/styles/colors.md
+++ b/apps/style-web/src/pages/style/en/styles/colors.md
@@ -13,6 +13,8 @@ Color system in KTH Style is based on KTH graphical identity and implements acce
 
 The new graphical identity defines 6 tones of primary colors. Five blues and one beige.
 
+<styleweb-color-table>
+
 | Name                | Hex value |
 | ------------------- | --------- |
 | $color-sand         | #e6e1dd   |
@@ -22,7 +24,11 @@ The new graphical identity defines 6 tones of primary colors. Five blues and one
 | $color-blue-light   | #e0edfc   |
 | $color-blue-digital | #221dd9   |
 
+</styleweb-color-table>
+
 In addition to that, KTH Style uses the following colors to meet various needs
+
+<styleweb-color-table>
 
 | Name               | Hex value |
 | ------------------ | --------- |
@@ -38,6 +44,8 @@ In addition to that, KTH Style uses the following colors to meet various needs
 | $color-green-light | #d8ffe7   |
 | $color-green       | #3f824e   |
 | $color-green-dark  | #366f43   |
+
+</styleweb-color-table>
 
 ## Semantic colors (semantic tokens)
 

--- a/apps/style-web/src/pages/style/en/styles/colors.md
+++ b/apps/style-web/src/pages/style/en/styles/colors.md
@@ -54,7 +54,7 @@ Example:
 
 Surface colors are used for large surfaces like a header or the whole page. They are:
 
-- `--color-background`. Color for the background of the surface
+- `--color-background` and `--color-background-alt`. Color for the background of the surface
 - `--color-text`. Color for texts that are directly written on the surface
 
 Primary colors are used for UI components with a "primary" appearance:
@@ -71,11 +71,11 @@ Secondary colors and tertiary are used for UI elements with secondary and tertia
 - `--color-secondary`. Main color for secondary components with borders. For border, texts and icons
 - `--color-tertiary`. Main color for secondary components without borders. For texts and icons
 
-Accessibility: UI components that use `--color-tertiary` **must** have extra elements to indicate they are interactive. For example:
+Accessibility: UI components that use `--color-tertiary` **must** be distinguishable from non-interactive text that surrounding them. For example:
 
-- Specific position: a link placed in a navigation area
 - A decoration: an underlined link
 - Extra elements: icons for collappse and dropdowns
+- List of links where the title (not a link) have a different font style
 
 ### Success and error colors
 

--- a/apps/style-web/src/pages/style/en/styles/colors.md
+++ b/apps/style-web/src/pages/style/en/styles/colors.md
@@ -7,18 +7,37 @@ layout: "@layouts/Page.astro"
 
 Color system in KTH Style is based on KTH graphical identity and implements accessible contrast requirements by default.
 
-## Brand colors (reference tokens)
+## Reference tokens
 
-> [!Note]
-> This section is under development
+> [!Note] You should not use reference tokens if there is a semantic token available.
 
 The new graphical identity defines 6 tones of primary colors. Five blues and one beige.
 
-![](@images/color-blues.png)
+| Name                | Hex value |
+| ------------------- | --------- |
+| $color-sand         | #e6e1dd   |
+| $color-blue-kth     | #004791   |
+| $color-blue-sky     | #6298d2   |
+| $color-blue-marine  | #08004f   |
+| $color-blue-light   | #e0edfc   |
+| $color-blue-digital | #221dd9   |
 
-- All reference tokens are defined as Sass variables.
-- KTH Style has defined extra colors for specific web uses outside of the graphical identity
-- You should not use reference tokens if there is a semantic token available.
+In addition to that, KTH Style uses the following colors to meet various needs
+
+| Name               | Hex value |
+| ------------------ | --------- |
+| $color-white       | #fcfcfc   |
+| $color-gray-light  | #e6e6e6   |
+| $color-gray-medium | #a5a5a5   |
+| $color-gray-dark   | #323232   |
+| $color-black       | #212121   |
+| $color-blue-lake   | #036eb8   |
+| $color-red-light   | #fad6d6   |
+| $color-red         | #d8351e   |
+| $color-red-dark    | #bf2c17   |
+| $color-green-light | #d8ffe7   |
+| $color-green       | #3f824e   |
+| $color-green-dark  | #366f43   |
 
 ## Semantic colors (semantic tokens)
 

--- a/apps/style-web/src/pages/style/en/styles/colors.md
+++ b/apps/style-web/src/pages/style/en/styles/colors.md
@@ -109,25 +109,7 @@ We are still working on colors for:
 ### Colors for states
 
 > [!Note]
-> We are still working on colors for hover
-
-We think it is possible to define just one "overlay" color (something like a black with 10% opacity) and "merge" both the normal color with CSS:
-
-```scss
-// --hover-overlay transparent by default:
-button.primary {
-  background: var(--color-primary), var(--hover-overlay, transparent);
-}
-
-button.secondary {
-  background: var(--hover-overlay);
-}
-
-// We don't need to style every hover component. Just need to set the value for the overlay and components will read the value
-:hover {
-  --hover-overlay: rgb(0 0 0 / 0.1);
-}
-```
+> We are still working on colors for hover, active and inactive states
 
 Some components need to signal an "active" or "inactive" states:
 

--- a/apps/style-web/src/pages/style/en/styles/colors.md
+++ b/apps/style-web/src/pages/style/en/styles/colors.md
@@ -146,16 +146,7 @@ KTH Style defines the following 4 color themes:
 
 ## Accessibility
 
-> [!Note]
-> This section is important only if you are implementing a new theme
-
-All colors in a given theme must met the WCAG contrast requirements for the purpose that are designed for. Example:
-
-- `--color-background` and `--color-text` should have as highest contrast as possible since they are colors for background and normal text. At least 7:1 is desired
-- `--color-background` should have contrast with `--color-primary`, `--color-error` and `--color-success` (all of the three) of at least 4.5:1 since the latter three appear always on the background.
-- `--color-on-primary` should have contrast with `--color-primary`, `--color-error` and `--color-success` (all of the three) of at least 4.5:1
-- `--color-secondary` should have 4.5:1 contrast with `--color-background`
-- `--color-tertiary` should have 4.5:1 contrast with `--color-bacakground`. It is recommended to have a 3:1 contrast with `--color-text`.
+Check contrast requirements in [color accessibility test](../examples/a11y-colors).
 
 ## How to use semantic tokens
 

--- a/apps/style-web/src/pages/style/en/styles/colors.md
+++ b/apps/style-web/src/pages/style/en/styles/colors.md
@@ -79,17 +79,14 @@ Accessibility: UI components that use `--color-tertiary` **must** have extra ele
 
 ### Success and error colors
 
-> [!Note]
-> These colors are not defined yet in `colors.scss`. We need to set values for them in all themes
-
 Used to indicate success and error.
+
+> [!Note] UI components should not rely only on color to convey error or success meaning. Use icons, labels and other additional elements
 
 ![](@images/color-error-success.png)
 
 - `--color-error`. Color for errors. Used in borders, texts and backgrounds of UI elements
 - `--color-success`. Color for success. Used in borders, texts and backgrounds of UI elements
-
-Accessibility: UI components should not rely only on color to convey error or success meaning. Use icons, labels and other additional elements
 
 ### Other colors
 


### PR DESCRIPTION
This PR augments the colors tokens in KTH Style.

- **Breaking** (only in Sass). Changes the color name `$color-blue-special` to `$color-blue-lake`, which is more consistent with other "blue" reference tokens.
- **Value update**. Changes the color `--color-tertiary` in intranet theme from `$color-blue-lake` to `$color-blue-kth` to meet a11y requirements.
- **New semantic colors**: `--color-success`, `--color-error`, `--color-background-alt`
- **New values**. New reference colors for reds, greens and grays

Other changes:

- Updates the documentation
- Adds a new page where users can check the contrast requirements of our colors