### PR TITLE
Sticky header for mobile

### DIFF
--- a/@kth/style/scss/components/header.scss
+++ b/@kth/style/scss/components/header.scss
@@ -1,5 +1,6 @@
 @use "../tokens/colors.scss";
 @use "../tokens/spacing.scss";
+@use "../tokens/sizing.scss";
 @use "../utils/mixins.scss";
 
 @layer kth-style {
@@ -26,7 +27,14 @@
     color: var(--color-text);
     background: var(--color-background);
     padding-block: spacing.$space-16;
-    position: relative;
+    position: fixed;
+    top: 2.5rem;
+    width: 100%;
+    transition: padding-block 500ms cubic-bezier(0.05, 0.7, 0.1, 1);
+
+    .kth-logotype {
+      transition: all 200ms linear;
+    }
 
     &__container {
       @include mixins.container;
@@ -44,6 +52,20 @@
 
     &__mega-menu--collapsable {
       display: none;
+    }
+  }
+
+  @media (max-width: sizing.$breakpoint-64) {
+    .kth-header.collapsed {
+      // transition: padding-block 500ms cubic-bezier(0.05, 0.7, 0.1, 1);
+      padding-block: spacing.$space-8;
+
+      .kth-logotype {
+        block-size: 0rem;
+        // inline-size: 0rem;
+        opacity: 0;
+        // transition: all 50ms linear;
+      }
     }
   }
 }

--- a/@kth/style/scss/components/header.scss
+++ b/@kth/style/scss/components/header.scss
@@ -29,6 +29,9 @@
 
   .kth-header {
     position: absolute;
+
+    // TODO: convert to its own token
+    z-index: 10;
     top: var(--height-kpm, 0);
     color: var(--color-text);
     background: var(--color-background);

--- a/@kth/style/scss/components/header.scss
+++ b/@kth/style/scss/components/header.scss
@@ -57,14 +57,14 @@
 
   @media (max-width: sizing.$breakpoint-64) {
     .kth-header.collapsed {
-      // transition: padding-block 500ms cubic-bezier(0.05, 0.7, 0.1, 1);
       padding-block: spacing.$space-8;
+
+      // TODO: Define this shadow as a token
+      box-shadow: 0 0.125rem 0.5rem 0 rgb(0 0 0 /0.15);
 
       .kth-logotype {
         block-size: 0rem;
-        // inline-size: 0rem;
         opacity: 0;
-        // transition: all 50ms linear;
       }
     }
   }

--- a/@kth/style/scss/components/header.scss
+++ b/@kth/style/scss/components/header.scss
@@ -23,12 +23,16 @@
     }
   }
 
+  :root {
+    --height-header: 6rem;
+  }
+
   .kth-header {
+    position: absolute;
+    top: var(--height-kpm, 0);
     color: var(--color-text);
     background: var(--color-background);
     padding-block: spacing.$space-16;
-    position: fixed;
-    top: 2.5rem;
     width: 100%;
     transition: padding-block 500ms cubic-bezier(0.05, 0.7, 0.1, 1);
 
@@ -55,7 +59,12 @@
     }
   }
 
+  // Fixed header in mobile
   @media (max-width: sizing.$breakpoint-64) {
+    .kth-header {
+      position: fixed;
+    }
+
     .kth-header.collapsed {
       padding-block: spacing.$space-8;
 

--- a/@kth/style/scss/components/kpm.scss
+++ b/@kth/style/scss/components/kpm.scss
@@ -8,9 +8,11 @@
   .kth-kpm {
     position: fixed;
     width: 100%;
+    // TODO: Convert to its own token
     z-index: 10;
     background: var(--color-background);
     top: 0;
+
     &__container {
       @include mixins.container;
       display: flex;

--- a/@kth/style/scss/components/kpm.scss
+++ b/@kth/style/scss/components/kpm.scss
@@ -1,6 +1,10 @@
 @use "../utils/mixins.scss";
 
 @layer kth-style {
+  :root {
+    --height-kpm: 2.5rem;
+  }
+
   .kth-kpm {
     position: fixed;
     width: 100%;

--- a/@kth/style/scss/components/kpm.scss
+++ b/@kth/style/scss/components/kpm.scss
@@ -2,6 +2,11 @@
 
 @layer kth-style {
   .kth-kpm {
+    position: fixed;
+    width: 100%;
+    z-index: 10;
+    background: var(--color-background);
+    top: 0;
     &__container {
       @include mixins.container;
       display: flex;

--- a/@kth/style/scss/components/logotype.scss
+++ b/@kth/style/scss/components/logotype.scss
@@ -1,4 +1,5 @@
 @use "../tokens/spacing.scss";
+@use "../tokens/sizing.scss";
 
 @layer kth-style {
   a.kth-logotype,
@@ -10,8 +11,9 @@
     border: none;
     margin: 0;
 
-    // TODO: less margin for mobile
-    margin-inline-end: spacing.$space-32;
+    @media (min-width: sizing.$breakpoint-64) {
+      margin-inline-end: spacing.$space-32;
+    }
     padding: 0;
 
     // Defensive measurement:

--- a/@kth/style/scss/components/logotype.scss
+++ b/@kth/style/scss/components/logotype.scss
@@ -21,8 +21,8 @@
     }
 
     img {
-      block-size: 100%;
-      inline-size: 100%;
+      block-size: 4rem;
+      inline-size: 4rem;
     }
   }
 }

--- a/@kth/style/scss/components/logotype.scss
+++ b/@kth/style/scss/components/logotype.scss
@@ -3,11 +3,14 @@
 @layer kth-style {
   a.kth-logotype,
   figure.kth-logotype {
+    overflow: hidden;
     display: inline-block;
     block-size: 4rem;
     inline-size: 4rem;
     border: none;
     margin: 0;
+
+    // TODO: less margin for mobile
     margin-inline-end: spacing.$space-32;
     padding: 0;
 
@@ -18,9 +21,12 @@
     > figure {
       block-size: 100%;
       inline-size: 100%;
+      position: relative;
     }
 
     img {
+      position: absolute;
+      bottom: 0;
       block-size: 4rem;
       inline-size: 4rem;
     }

--- a/@kth/style/scss/utils/reset.scss
+++ b/@kth/style/scss/utils/reset.scss
@@ -68,7 +68,16 @@ $generate-css: true !default;
       background: var(--color-background);
       min-height: 100vh;
       margin-inline: 0;
-      margin-block-start: calc(var(--height-kpm, 0) + var(--height-header, 0));
+
+      // `--height-kpm` is set by (new) KPM or `kpm.scss`
+      // `--kpm-bar-height` is the old (current) name for the variable set by KPM
+      // default value is 0 (no kpm at all)
+
+      // `--height-header` is set when including `header.scss`
+      // default value is 0 (no header)
+      margin-block-start: calc(
+        var(--height-kpm, --kpm-bar-height, 0) + var(--height-header, 0)
+      );
     }
 
     @include reset;

--- a/@kth/style/scss/utils/reset.scss
+++ b/@kth/style/scss/utils/reset.scss
@@ -67,7 +67,8 @@ $generate-css: true !default;
       color: var(--color-text);
       background: var(--color-background);
       min-height: 100vh;
-      margin: 0;
+      margin-inline: 0;
+      margin-block-start: calc(var(--height-kpm, 0) + var(--height-header, 0));
     }
 
     @include reset;

--- a/@kth/style/src/components/ScrollObserver.ts
+++ b/@kth/style/src/components/ScrollObserver.ts
@@ -1,0 +1,34 @@
+interface Options {
+  threshold: number;
+  className: string;
+}
+
+const DEFAULT_OPTIONS: Options = {
+  threshold: 32,
+  className: "collapsed",
+};
+
+function toggleClass(
+  element: HTMLElement | null,
+  { threshold, className }: Options,
+) {
+  if (window.scrollY > threshold) {
+    element?.classList.add(className);
+  } else {
+    element?.classList.remove(className);
+  }
+}
+
+export class ScrollObserver {
+  /** Sets a class in an element when the window scroll is below a treshold */
+  static setClass(
+    element: HTMLElement | null,
+    options: Options = DEFAULT_OPTIONS,
+  ) {
+    toggleClass(element, options);
+
+    window.addEventListener("scroll", () => {
+      toggleClass(element, options);
+    });
+  }
+}

--- a/@kth/style/src/index.ts
+++ b/@kth/style/src/index.ts
@@ -1,1 +1,2 @@
 export { MenuPanel } from "./components/MenuPanel";
+export { ScrollObserver } from "./components/ScrollObserver";

--- a/apps/style-web/src/components/Header.astro
+++ b/apps/style-web/src/components/Header.astro
@@ -42,7 +42,7 @@ const t = useTranslations(lang);
 const navigationPanel = lang === "sv" ? navigationPanelSv : navigationPanelEn;
 ---
 
-<header class="kth-header intranet collapsed">
+<header class="kth-header intranet">
   <div class="kth-header__container">
     <MainHeaderLogotype alt={t("nav.go-home")} />
     <nav class="kth-mega-menu">
@@ -82,7 +82,7 @@ const navigationPanel = lang === "sv" ? navigationPanelSv : navigationPanelEn;
 </header>
 
 <script>
-  import { MenuPanel } from "@kth/style";
+  import { MenuPanel, ScrollObserver } from "@kth/style";
 
   // Set navigationPanels only to non-mobile versions
   MenuPanel.init(
@@ -104,15 +104,5 @@ const navigationPanel = lang === "sv" ? navigationPanelSv : navigationPanelEn;
     document.querySelector(".kth-mobile-menu"),
   );
 
-  const THRESHOLD = 32;
-
-  window.addEventListener("scroll", () => {
-    console.log("x", window.scrollY);
-    if (window.scrollY > THRESHOLD) {
-      console.log(document.querySelector(".kth-header"));
-      document.querySelector(".kth-header")?.classList.add("collapsed");
-    } else {
-      document.querySelector(".kth-header")?.classList.remove("collapsed");
-    }
-  });
+  ScrollObserver.setClass(document.querySelector(".kth-header"));
 </script>

--- a/apps/style-web/src/components/Header.astro
+++ b/apps/style-web/src/components/Header.astro
@@ -42,7 +42,7 @@ const t = useTranslations(lang);
 const navigationPanel = lang === "sv" ? navigationPanelSv : navigationPanelEn;
 ---
 
-<header class="kth-header intranet">
+<header class="kth-header intranet collapsed">
   <div class="kth-header__container">
     <MainHeaderLogotype alt={t("nav.go-home")} />
     <nav class="kth-mega-menu">
@@ -103,4 +103,16 @@ const navigationPanel = lang === "sv" ? navigationPanelSv : navigationPanelEn;
     document.querySelectorAll(".kth-mobile-menu__item"),
     document.querySelector(".kth-mobile-menu"),
   );
+
+  const THRESHOLD = 32;
+
+  window.addEventListener("scroll", () => {
+    console.log("x", window.scrollY);
+    if (window.scrollY > THRESHOLD) {
+      console.log(document.querySelector(".kth-header"));
+      document.querySelector(".kth-header")?.classList.add("collapsed");
+    } else {
+      document.querySelector(".kth-header")?.classList.remove("collapsed");
+    }
+  });
 </script>

--- a/apps/style-web/src/components/content.scss
+++ b/apps/style-web/src/components/content.scss
@@ -6,7 +6,6 @@
 .kth-content {
   @include mixins.container;
 
-  margin-block-start: 9.5rem;
   margin-block-end: spacing.$space-64;
   display: grid;
   grid-template-areas:

--- a/apps/style-web/src/components/content.scss
+++ b/apps/style-web/src/components/content.scss
@@ -6,7 +6,7 @@
 .kth-content {
   @include mixins.container;
 
-  margin-block-start: spacing.$space-20;
+  margin-block-start: 9.5rem;
   margin-block-end: spacing.$space-64;
   display: grid;
   grid-template-areas:


### PR DESCRIPTION
This PR adds:

- A script `ScrollObserver` that sets/unsets a CSS class into an element depending on the window scroll
- Two CSS variables (`--height-kpm` and `--height-header`)

The main idea is:

- `header.scss` sets `--height-header` variable.
- KPM sets the `--height-kpm` variable. For retro-compatibility reasons, I've included `--kpm-bar-height`, which is the name used __today__
- The value of both variables is read in the `body` for its margin