### PR TITLE
Activate sticky header

### DIFF
--- a/@kth/style/scss/components/header.scss
+++ b/@kth/style/scss/components/header.scss
@@ -23,12 +23,25 @@
     }
   }
 
+  :root {
+    --height-header: 6rem;
+  }
+
   .kth-header {
+    position: absolute;
+
+    // TODO: convert to its own token
+    z-index: 10;
+    top: var(--height-kpm, 0);
     color: var(--color-text);
     background: var(--color-background);
     padding-block: spacing.$space-16;
     width: 100%;
     transition: padding-block 500ms cubic-bezier(0.05, 0.7, 0.1, 1);
+
+    .kth-logotype {
+      transition: all 200ms linear;
+    }
 
     &__container {
       @include mixins.container;
@@ -47,6 +60,25 @@
 
     &__mega-menu--collapsable {
       display: none;
+    }
+  }
+
+  // Fixed header in mobile
+  @media (max-width: sizing.$breakpoint-64) {
+    .kth-header {
+      position: fixed;
+    }
+
+    .kth-header.collapsed {
+      padding-block: spacing.$space-8;
+
+      // TODO: Define this shadow as a token
+      box-shadow: 0 0.125rem 0.5rem 0 rgb(0 0 0 /0.15);
+
+      .kth-logotype {
+        block-size: 0rem;
+        opacity: 0;
+      }
     }
   }
 }

--- a/@kth/style/scss/components/kpm.scss
+++ b/@kth/style/scss/components/kpm.scss
@@ -1,7 +1,18 @@
 @use "../utils/mixins.scss";
 
 @layer kth-style {
+  :root {
+    --height-kpm: 2.5rem;
+  }
+
   .kth-kpm {
+    position: fixed;
+    width: 100%;
+    // TODO: Convert to its own token
+    z-index: 10;
+    background: var(--color-background);
+    top: 0;
+
     &__container {
       @include mixins.container;
       display: flex;

--- a/@kth/style/scss/components/logotype.scss
+++ b/@kth/style/scss/components/logotype.scss
@@ -4,11 +4,16 @@
 @layer kth-style {
   a.kth-logotype,
   figure.kth-logotype {
+    overflow: hidden;
     display: inline-block;
     block-size: 4rem;
     inline-size: 4rem;
     border: none;
     margin: 0;
+
+    @media (min-width: sizing.$breakpoint-64) {
+      margin-inline-end: spacing.$space-32;
+    }
     padding: 0;
 
     // Defensive measurement:
@@ -18,6 +23,14 @@
     > figure {
       block-size: 100%;
       inline-size: 100%;
+      position: relative;
+    }
+
+    img {
+      position: absolute;
+      bottom: 0;
+      block-size: 4rem;
+      inline-size: 4rem;
     }
   }
 }

--- a/@kth/style/scss/utils/reset.scss
+++ b/@kth/style/scss/utils/reset.scss
@@ -100,7 +100,8 @@ $generate-css: true !default;
       // `--height-header` is set when including `header.scss`
       // default value is 0 (no header)
       margin-block-start: calc(
-        var(--height-kpm, --kpm-bar-height, 0) + var(--height-header, 0)
+        var(--height-kpm, var(--kpm-bar-height, 0rem)) +
+          var(--height-header, 0rem)
       );
     }
 

--- a/@kth/style/scss/utils/reset.scss
+++ b/@kth/style/scss/utils/reset.scss
@@ -91,6 +91,17 @@ $generate-css: true !default;
       color: var(--color-text);
       background: var(--color-background);
       min-height: 100vh;
+      margin-inline: 0;
+
+      // `--height-kpm` is set by (new) KPM or `kpm.scss`
+      // `--kpm-bar-height` is the old (current) name for the variable set by KPM
+      // default value is 0 (no kpm at all)
+
+      // `--height-header` is set when including `header.scss`
+      // default value is 0 (no header)
+      margin-block-start: calc(
+        var(--height-kpm, --kpm-bar-height, 0) + var(--height-header, 0)
+      );
     }
 
     @include reset;


### PR DESCRIPTION
This PR re-enables sticky header.

NOTE: this should be merged after fixing KPM JavaScript that injects CSS