### PR TITLE
Remove margin after logotype in small screens

### DIFF
--- a/@kth/style/scss/components/logotype.scss
+++ b/@kth/style/scss/components/logotype.scss
@@ -10,6 +10,7 @@
     border: none;
     margin: 0;
     padding: 0;
+    margin-inline-end: spacing.$space-8;
 
     @media (min-width: sizing.$breakpoint-40) {
       margin-inline-end: spacing.$space-32;

--- a/@kth/style/scss/components/logotype.scss
+++ b/@kth/style/scss/components/logotype.scss
@@ -9,8 +9,11 @@
     inline-size: 4rem;
     border: none;
     margin: 0;
-    margin-inline-end: spacing.$space-32;
     padding: 0;
+
+    @media (min-width: sizing.$breakpoint-40) {
+      margin-inline-end: spacing.$space-32;
+    }
 
     // Defensive measurement:
     // - We prevent logo from shrinking


### PR DESCRIPTION
This PR removes a margin in the left of the logotype which make menus to span multiple lines in small screens.

After the change, the menu is displayed correctly for all devices with a width 360px or higher